### PR TITLE
Swap order for cl65 options and filename

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -76,14 +76,14 @@ function getAssemblerCommandLine(fileName: string, ld65Config: string | undefine
 		cli = `cl65`;
 	}
 
-	cli += ` "${fileName}" `;
-
 	if (ld65Config) {
 		cli += `-C "${ld65Config}" `;
 	}
 	if (cl65Config && cl65Config.params) {
 		cli += cl65Config.params;
 	}
+
+	cli += ` "${fileName}" `;
 	return cli;
 }
 


### PR DESCRIPTION
`cl65` requires that the filename(s) of the source inputs go at the end of the command. Once it encounters the first source file, all the rest of the options are treated as files and this prevents users of the extension from adding new options with the `cl65config.json`

https://cc65.github.io/doc/cl65.html

```
Usage: cl65 [options] file [...]
```