### PR TITLE
Add Hudson Soft HuC6280 Opcodes (PC Engine/Turbografx-16)

### DIFF
--- a/syntaxes/ca65.tmLanguage.json
+++ b/syntaxes/ca65.tmLanguage.json
@@ -127,9 +127,13 @@
 				"name": "keyword.other.opcode.ca65.65816",
 				"match": "\\b(?i:bge|blt|cpa|dea|ina|swa|tad|tas|tda|tsa)\\b"
 			}, {
-				"comment": "HuC6280 Opcode Aliases",
-				"name": "keyword.other.opcode.ca65.huc8280",
+				"comment": "HuC6280 Opcodes",
+				"name": "keyword.other.opcode.ca65.huc6280",
 				"match": "\\b(?i:sxy|sax|say|cla|clx|cly|st0|st1|st2|tma|tam|tii|tst|tdd|tin|tia|tai|bsr|csl|csh|set)\\b"
+			}, {
+				"comment": "HuC6280 Opcode Aliases",
+				"name": "keyword.other.opcode.ca65.huc8280aliases",
+				"match": "\\b(?i:tam[0-7]|tma[0-7])\\b"
 			}]
 		},
 		"pseudovars": {

--- a/syntaxes/ca65.tmLanguage.json
+++ b/syntaxes/ca65.tmLanguage.json
@@ -132,7 +132,7 @@
 				"match": "\\b(?i:sxy|sax|say|cla|clx|cly|st0|st1|st2|tma|tam|tii|tst|tdd|tin|tia|tai|bsr|csl|csh|set)\\b"
 			}, {
 				"comment": "HuC6280 Opcode Aliases",
-				"name": "keyword.other.opcode.ca65.huc8280aliases",
+				"name": "keyword.other.opcode.ca65.huc6280aliases",
 				"match": "\\b(?i:tam[0-7]|tma[0-7])\\b"
 			}]
 		},

--- a/syntaxes/ca65.tmLanguage.json
+++ b/syntaxes/ca65.tmLanguage.json
@@ -126,6 +126,10 @@
 				"comment": "65816 Opcode Aliases",
 				"name": "keyword.other.opcode.ca65.65816",
 				"match": "\\b(?i:bge|blt|cpa|dea|ina|swa|tad|tas|tda|tsa)\\b"
+			}, {
+				"comment": "HuC6280 Opcode Aliases",
+				"name": "keyword.other.opcode.ca65.huc8280",
+				"match": "\\b(?i:sxy|sax|say|cla|clx|cly|st0|st1|st2|tma|tam|tii|tst|tdd|tin|tia|tai|bsr|csl|csh|set)\\b"
 			}]
 		},
 		"pseudovars": {


### PR DESCRIPTION
This adds syntax highlighting for the HuC6280 CPU, which is a variant of the 65C02 that's used in the PC Engine and Turbografx-16. This also includes ca65's aliases for tam0-tam7 and tma0-tma7 as opposed to writing `tam #$04` etc.

Reference: https://www.chrismcovell.com/PCEdev/HuC6280_opcodes.html

<img width="320" height="138" alt="Screenshot 2025-07-29 at 4 09 44 PM" src="https://github.com/user-attachments/assets/f4ba8997-8211-4886-a71b-857ce54107c9" />
